### PR TITLE
Add sub-project metrics repo

### DIFF
--- a/github-config.yaml
+++ b/github-config.yaml
@@ -55,6 +55,11 @@ orgs:
         description: ODH DevSecOps repository.
         has_projects: false
         has_wiki: false
+      metrics:
+        default_branch: main
+        description: Metrics project repository.
+        has_projects: false
+        has_wiki: false
     teams:
       AIOps:
         description: ""


### PR DESCRIPTION
This project aims to measure and monitor the work and contributions being made across all Open Services Initiatives, with the end goal of automating away much of the toil associated with project tracking and reporting. As we would like to eventually influence other groups in the ET org to adopt our data driven measurements, having the project repo under the open-services org seems suitable.