### PR TITLE
Add maintainers for metrics sub project

### DIFF
--- a/github-config.yaml
+++ b/github-config.yaml
@@ -121,3 +121,13 @@ orgs:
         privacy: closed
         repos:
           devsecops: admin
+      sp-metrics-leads:
+        description: Leads Team for sub-project metrics
+        maintainers:
+          - hemajv
+          - Shreyanand
+        members:
+          - harshad16
+        privacy: closed
+        repos:
+          metrics: admin


### PR DESCRIPTION
For issue https://github.com/open-services-group/metrics/issues/1, this PR adds maintainers for the metrics sub project.

cc @hemajv 