### PR TITLE
Revert creation of metrics team

### DIFF
--- a/github-config.yaml
+++ b/github-config.yaml
@@ -121,13 +121,3 @@ orgs:
         privacy: closed
         repos:
           devsecops: admin
-      sp-metrics-leads:
-        description: Leads Team for sub-project metrics
-        maintainers:
-          - hemajv
-          - Shreyanand
-        members:
-          - harshad16
-        privacy: closed
-        repos:
-          metrics: admin


### PR DESCRIPTION
Revert creation of metrics team
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>


Related-to: https://github.com/open-services-group/metrics/issues/1

The peribolos didn't execute, so the team was never created.
https://github.com/open-services-group/metrics/issues/1#issuecomment-1030228246