### PR TITLE
:exclamation: Peribolos binaries is shifted to /ko-app/ dir

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -25,7 +25,7 @@ presubmits:
             - -c
             - |
               set -ex
-              /peribolos --config-path github-config.yaml \
+              /ko-app/peribolos --config-path github-config.yaml \
                 --github-endpoint=http://ghproxy \
                 --github-endpoint=https://api.github.com \
                 --github-token-path /etc/github/oauth \
@@ -108,7 +108,7 @@ postsubmits:
             - -c
             - |
               set -ex
-              /peribolos --config-path github-config.yaml \
+              /ko-app/peribolos --config-path github-config.yaml \
                 --github-endpoint=http://ghproxy \
                 --github-endpoint=https://api.github.com \
                 --github-token-path /etc/github/oauth \


### PR DESCRIPTION
Peribolos binaries are shifted to /ko-app/ dir
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

Related-to: https://github.com/kubernetes/test-infra/issues/25440

### Description
https://github.com/kubernetes/test-infra/blob/master/prow/ANNOUNCEMENTS.md?plain=1#L195
