### PR TITLE
Update label_sync binary path

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -60,7 +60,7 @@ presubmits:
             - -c
             - |
               set -ex
-              /app/label_sync/app.binary \
+              /ko-app/label_sync \
               --config=labels.yaml \
               --orgs=open-services-group \
               --endpoint=http://ghproxy \
@@ -146,7 +146,7 @@ postsubmits:
             - -c
             - |
               set -ex
-              /app/label_sync/app.binary \
+              /ko-app/label_sync \
               --config=labels.yaml \
               --orgs=open-services-group \
               --endpoint=http://ghproxy \


### PR DESCRIPTION
Similar to #83, the `label_sync` binary also changed location.
