### PR TITLE
Add Tom and Shrey to org admin

### DIFF
--- a/github-config.yaml
+++ b/github-config.yaml
@@ -3,6 +3,8 @@ orgs:
     admins:
       - durandom
       - goern
+      - tumido
+      - Shreyanand
       - sesheta
     billing_email: goern@redhat.com
     company: "Red Hat, Inc."
@@ -32,10 +34,8 @@ orgs:
       - pacospace
       - SamoKopecky
       - schwesig
-      - Shreyanand
       - shreekarSS
       - suppathak
-      - tumido
       - xtuchyna
     members_can_create_repositories: false
     name: Open Services Group


### PR DESCRIPTION
For issue https://github.com/open-services-group/peribolos-as-a-service/issues/5, we need to create Github application in the OSG org. For that, we'd need access to admin permissions. 