### PR TITLE
Add an 'epic' label

### DIFF
--- a/labels.md
+++ b/labels.md
@@ -81,6 +81,7 @@ podman run --rm -v ./:/community:z \
 
 | Name | Description | Added By | Prow Plugin |
 | ---- | ----------- | -------- | --- |
+| <a id="epic" href="#epic">`epic`</a> | Tags an issue as an Epic.| humans | |
 | <a id="tide/merge-blocker" href="#tide/merge-blocker">`tide/merge-blocker`</a> | Denotes an issue that blocks the tide merge queue for a branch while it is open. <br><br> This was previously `merge-blocker`, | humans | |
 
 ## Labels that apply to all repos, only for PRs

--- a/labels.yaml
+++ b/labels.yaml
@@ -320,6 +320,12 @@ default:
       target: both
       addedBy: humans
 
+    - color: 4660f9
+      description: Tags an issue as an Epic.
+      name: epic
+      target: issues
+      addedBy: humans
+
 repos:
   open-services-group/community:
     labels:


### PR DESCRIPTION
This is to make a new label available to the OSG repos: `epic`

That label is meant to be used to tag issues that are Epics.