### PR TITLE
feat: Add probot-template repo

### DIFF
--- a/github-config.yaml
+++ b/github-config.yaml
@@ -68,6 +68,10 @@ orgs:
         description: Extensions to Probot App when run as a service
         has_projects: false
         has_wiki: false
+      probot-template:
+        description: Template for Probot on Kubernetes
+        has_projects: false
+        has_wiki: false
     teams:
       AIOps:
         description: ""
@@ -161,3 +165,4 @@ orgs:
         repos:
           peribolos-as-a-service: admin
           probot-extensions: admin
+          probot-template: admin


### PR DESCRIPTION
Add `probot-template` repo that will map and generalize `peribolos-as-a-service` content as a generic template repo ready to use for other bot controllers. 