### PR TITLE
update DS-SIG docs to reflect Q3 team changes

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -3,8 +3,7 @@ aliases:
     - codificat
     - schwesig
   sig-data-science-leads:
-    - erikerlandson
-    - michaelclifford
+    - durandom
   sig-services-leads:
     - Shreyanand
     - tumido
@@ -18,7 +17,6 @@ aliases:
   committee-steering:
     - durandom
     - goern
-    - michaelclifford
     - schwesig
     - tumido
 ## BEGIN CUSTOM CONTENT

--- a/committee-steering/README.md
+++ b/committee-steering/README.md
@@ -21,7 +21,6 @@ The Steering Committee is the governing body of the Open Services Group, The Ste
 
 * Marcel Hild (**[@durandom](https://github.com/durandom)**), Red Hat
 * Christoph Görn (**[@goern](https://github.com/goern)**), Red Hat
-* Michael Clifford (**[@michaelclifford](https://github.com/michaelclifford)**), Red Hat
 * Thorsten Schwesig (**[@schwesig](https://github.com/schwesig)**), Red Hat
 * Tom Coufal (**[@tumido](https://github.com/tumido)**), Red Hat
 

--- a/liaisons.md
+++ b/liaisons.md
@@ -26,7 +26,7 @@ of SIGs, WGs and UGs.
 | Community Group            | Steering Committee Liaison |
 | -------------------------- | -------------------------- |
 | [SIG Community Experience](sig-community-experience/README.md) | Thorsten Schwesig (**[@schwesig](https://github.com/schwesig)**) |
-| [SIG Data Science](sig-data-science/README.md) | Michael Clifford (**[@michaelclifford](https://github.com/michaelclifford)**) |
+| [SIG Data Science](sig-data-science/README.md) | Marcel Hild (**[@durandom](https://github.com/durandom)**) |
 | [SIG Services](sig-services/README.md) | Tom Coufal (**[@tumido](https://github.com/tumido)**) |
 <!-- BEGIN CUSTOM CONTENT -->
 

--- a/sig-data-science/README.md
+++ b/sig-data-science/README.md
@@ -15,72 +15,31 @@ Covers all aspects of Data Science and Machine Learning as it pertains to the op
 The [charter](charter.md) defines the scope and governance of the Data Science Special Interest Group.
 
 ## Meetings
-* Data Science SIG meeting: [Wednesdays at 11:00 ET (East Time)](https://meet.google.com/ufs-hgvi-oni) (bi-weekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=11:00&tz=ET%20%28East%20Time%29).
+* Data Science SIG meeting: [Wednesdays at 11:00 ET (East Time)](https://meet.google.com/ufs-hgvi-oni) (quarterly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=11:00&tz=ET%20%28East%20Time%29).
   * [Meeting notes and Agenda](https://docs.google.com/document/d/1KecKMMva2wQxUZFdBpd291q75Z7ATp7F1YihMbuC_xg/edit).
-* Metrics Project Meeting: [Mondays at 12:00 ET (East Time)](https://meet.google.com/efp-yipi-ibj) (weekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=12:00&tz=ET%20%28East%20Time%29).
-  * [Meeting notes and Agenda](https://docs.google.com/document/d/1lZ9863luHo_LoXGz27QrMuMxVWiinfLm7N5fJP4OInE/edit).
-* OS-Climate Project Meeting: [Thursdays at 11:00 ET (East Time)](https://meet.google.com/kdy-sqyf-rud) (weekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=11:00&tz=ET%20%28East%20Time%29).
-  * [Meeting notes and Agenda](https://docs.google.com/document/d/1PZTRTrU68LZXUy9GgKCp38KpVyG4lrN5Cw8Zv9pGmjE/edit).
-* Operate First Data Science Community Project Meeting: [Wednesdays at 12:00 ET (East Time)](https://meet.google.com/ngp-npcx-nws) (weekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=12:00&tz=ET%20%28East%20Time%29).
-  * [Meeting notes and Agenda](https://docs.google.com/document/d/19_xPxfsazD6rJfe1aHNjVC9_bKpOfnepsifCZ4GBw8o/edit).
 
 ## Leadership
 
 ### Chairs
 The Chairs of the SIG run operations and processes governing the SIG.
 
-* Erik Erlandson (**[@erikerlandson](https://github.com/erikerlandson)**), Red Hat
-* Michael Clifford (**[@michaelclifford](https://github.com/michaelclifford)**), Red Hat
+* Marcel Hild (**[@durandom](https://github.com/durandom)**), Red Hat
 
 ## Contact
 - [Mailing list]()
 - [Open Community Issues/PRs](https://github.com/open-services-group/community/labels/sig%2Fdata-science)
-- Steering Committee Liaison: Michael Clifford (**[@michaelclifford](https://github.com/michaelclifford)**)
+- Steering Committee Liaison: Marcel Hild (**[@durandom](https://github.com/durandom)**)
 
 ## Subprojects
 
 The following [subprojects][subproject-definition] are owned by sig-data-science:
-### Metrics
-[Described below](#metrics)
+### example
+example subproject
 - **Owners:**
   - [open-services-group/metrics](https://github.com/open-services-group/metrics/blob/main/OWNERS)
-### OS-Climate
-[Described below](#os-climate)
-- **Owners:**
-  - [os-climate/aicoe-osc-demo](https://github.com/os-climate/aicoe-osc-demo/blob/master/OWNERS)
-  - [os-climate/data-platform-demo](https://github.com/os-climate/data-platform-demo/blob/master/OWNERS)
-  - [os-climate/osc-ingest-tools](https://github.com/os-climate/osc-ingest-tools/blob/main/OWNERS)
-  - [os-climate/osc-trino-acl-dsl](https://github.com/os-climate/osc-trino-acl-dsl/blob/main/OWNERS)
-### Operate First Data Science Community
-[Described below](#operate-first-data-science-community)
-- **Owners:**
-  - [aicoe-aiops/operate-first-data-science-community](https://github.com/aicoe-aiops/operate-first-data-science-community/blob/main/OWNERS)
 
 [subproject-definition]: https://github.com/open-services-group/community/blob/main/governance.md#subprojects
 [subproject-lifecycle]: https://github.com/open-services-group/community/blob/main/subproject-lifecycle.md
 <!-- BEGIN CUSTOM CONTENT -->
-
-# Details about SIG Data Science sub-projects
-
-## Operate First Data Science Community
-
-This subproject is responsible for organizing, hosting, promoting and growing the Operate First Data Science Community and its associated meetup.
-
-The  Operate First Data Science Community aims to embrace the multidisciplinary nature of the current state of AI operations and cloud infrastructure by discussing technical topics relevant to data scientists, software developers, DevOps professionals, statisticians, and the intersection of their work, all in an open and collaborative public platform.
-
-[Project Repository](https://github.com/aicoe-aiops/operate-first-data-science-community)
-
-## OS-Climate
-
-This subproject is responsible for supporting the data science efforts of the OS-Climate community.
-
-
-[OS-Climate Github Organization](https://github.com/os-climate)
-
-## Metrics
-
-This subproject is responsible for measuring and tracking the progress and contribution made across the Open Services group.
-
-[Project Repository](https://github.com/open-services-group/metrics)
 
 <!-- END CUSTOM CONTENT -->

--- a/sig-list.md
+++ b/sig-list.md
@@ -35,7 +35,7 @@ When the need arises, a [new SIG can be created](sig-wg-lifecycle.md)
 | Name | Label | Chairs | Contact | Meetings |
 |------|-------|--------|---------|----------|
 |[Community Experience](sig-community-experience/README.md)|community-experience|* [Pep Turró Mauri](https://github.com/codificat), Red Hat<br>* [Thorsten Schwesig](https://github.com/schwesig), Red Hat<br>||* SIG Community Experience Meeting: [Wednesdays at 11:00 ET (East Time) (monthly)](https://meet.google.com/tig-yuxq-fyh)<br>
-|[Data Science](sig-data-science/README.md)|data-science|* [Erik Erlandson](https://github.com/erikerlandson), Red Hat<br>* [Michael Clifford](https://github.com/michaelclifford), Red Hat<br>||* Data Science SIG meeting: [Wednesdays at 11:00 ET (East Time) (bi-weekly)](https://meet.google.com/ufs-hgvi-oni)<br>* Metrics Project Meeting: [Mondays at 12:00 ET (East Time) (weekly)](https://meet.google.com/efp-yipi-ibj)<br>* OS-Climate Project Meeting: [Thursdays at 11:00 ET (East Time) (weekly)](https://meet.google.com/kdy-sqyf-rud)<br>* Operate First Data Science Community Project Meeting: [Wednesdays at 12:00 ET (East Time) (weekly)](https://meet.google.com/ngp-npcx-nws)<br>
+|[Data Science](sig-data-science/README.md)|data-science|* [Marcel Hild](https://github.com/durandom), Red Hat<br>||* Data Science SIG meeting: [Wednesdays at 11:00 ET (East Time) (quarterly)](https://meet.google.com/ufs-hgvi-oni)<br>
 |[Services](sig-services/README.md)|services|* [Shrey Anand](https://github.com/Shreyanand), Red Hat<br>* [Tom Coufal](https://github.com/tumido), Red Hat<br>||* Peribolos-as-a-service planning meeting: [Thursdays at 14:00 UTC (bi-weekly (alternates with Regular SIG Meeting))](https://meet.google.com/haz-qamk-qci)<br>* Regular SIG Meeting: [Thursdays at 14:00 UTC (bi-weekly)](https://meet.google.com/qhw-vgww-pdu)<br>
 
 ### Working Groups
@@ -50,7 +50,7 @@ When the need arises, a [new SIG can be created](sig-wg-lifecycle.md)
 
 | Name |  Label | Members | Contact |
 |------|--------|---------|---------|
-|[Steering](committee-steering/README.md)|steering|* [Marcel Hild](https://github.com/durandom), Red Hat<br>* [Christoph Görn](https://github.com/goern), Red Hat<br>* [Michael Clifford](https://github.com/michaelclifford), Red Hat<br>* [Thorsten Schwesig](https://github.com/schwesig), Red Hat<br>* [Tom Coufal](https://github.com/tumido), Red Hat<br>|
+|[Steering](committee-steering/README.md)|steering|* [Marcel Hild](https://github.com/durandom), Red Hat<br>* [Christoph Görn](https://github.com/goern), Red Hat<br>* [Thorsten Schwesig](https://github.com/schwesig), Red Hat<br>* [Tom Coufal](https://github.com/tumido), Red Hat<br>|
 <!-- BEGIN CUSTOM CONTENT -->
 
 <!-- END CUSTOM CONTENT -->

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -40,61 +40,26 @@ sigs:
   label: data-science
   leadership:
     chairs:
-    - github: erikerlandson
-      name: Erik Erlandson
-      company: Red Hat
-    - github: michaelclifford
-      name: Michael Clifford
+    - github: durandom
+      name: Marcel Hild
       company: Red Hat
   meetings:
   - description: Data Science SIG meeting
     day: Wednesday
     time: "11:00"
     tz: ET (East Time)
-    frequency: bi-weekly
+    frequency: quarterly
     url: https://meet.google.com/ufs-hgvi-oni
     archive_url: https://docs.google.com/document/d/1KecKMMva2wQxUZFdBpd291q75Z7ATp7F1YihMbuC_xg/edit
-  - description: Metrics Project Meeting
-    day: Monday
-    time: "12:00"
-    tz: ET (East Time)
-    frequency: weekly
-    url: https://meet.google.com/efp-yipi-ibj
-    archive_url: https://docs.google.com/document/d/1lZ9863luHo_LoXGz27QrMuMxVWiinfLm7N5fJP4OInE/edit
-  - description: OS-Climate Project Meeting
-    day: Thursday
-    time: "11:00"
-    tz: ET (East Time)
-    frequency: weekly
-    url: https://meet.google.com/kdy-sqyf-rud
-    archive_url: https://docs.google.com/document/d/1PZTRTrU68LZXUy9GgKCp38KpVyG4lrN5Cw8Zv9pGmjE/edit
-  - description: Operate First Data Science Community Project Meeting
-    day: Wednesday
-    time: "12:00"
-    tz: ET (East Time)
-    frequency: weekly
-    url: https://meet.google.com/ngp-npcx-nws
-    archive_url: https://docs.google.com/document/d/19_xPxfsazD6rJfe1aHNjVC9_bKpOfnepsifCZ4GBw8o/edit
   contact:
     liaison:
-      github: michaelclifford
-      name: Michael Clifford
+      github: durandom
+      name: Marcel Hild
   subprojects:
-  - name: Metrics
-    description: '[Described below](#metrics)'
+  - name: example
+    description: example subproject
     owners:
     - https://raw.githubusercontent.com/open-services-group/metrics/main/OWNERS
-  - name: OS-Climate
-    description: '[Described below](#os-climate)'
-    owners:
-    - https://raw.githubusercontent.com/os-climate/aicoe-osc-demo/master/OWNERS
-    - https://raw.githubusercontent.com/os-climate/data-platform-demo/master/OWNERS
-    - https://raw.githubusercontent.com/os-climate/osc-ingest-tools/main/OWNERS
-    - https://raw.githubusercontent.com/os-climate/osc-trino-acl-dsl/main/OWNERS
-  - name: Operate First Data Science Community
-    description: '[Described below](#operate-first-data-science-community)'
-    owners:
-    - https://raw.githubusercontent.com/aicoe-aiops/operate-first-data-science-community/main/OWNERS
 - dir: sig-services
   name: Services
   mission_statement: >
@@ -218,9 +183,6 @@ committees:
       company: Red Hat
     - github: goern
       name: Christoph Görn
-      company: Red Hat
-    - github: michaelclifford
-      name: Michael Clifford
       company: Red Hat
     - github: schwesig
       name: Thorsten Schwesig


### PR DESCRIPTION
Updated all the SIG docs to reflect the transition of the DS folks out of the OSG team. Left the DS SIG intact, but moved the meeting cadence to quarterly and removed all the sub-projects. Also, where a person needed to be named, I used @durandom as a place holder. :slightly_smiling_face: 

Let me know if you have any questions or comments on any of these edits.

Thanks! 