### PR TITLE
Enable the team to maintain the scrum repo

### DIFF
--- a/github-config.yaml
+++ b/github-config.yaml
@@ -19,8 +19,8 @@ orgs:
       - aakankshaduggal
       - chauhankaranraj
       - codificat
+      - dmick
       - erikerlandson
-      - fridex
       - Gkrumbach07
       - Gregory-Pereira
       - harshad16
@@ -32,14 +32,12 @@ orgs:
       - MichaelClifford
       - mimotej
       - oindrillac
-      - pacospace
       - SamoKopecky
       - schwesig
       - shreekarSS
       - suppathak
       - VannTen
       - xtuchyna
-      - dmick
     members_can_create_repositories: false
     name: Open Services Group
     repos:
@@ -119,7 +117,6 @@ orgs:
       wg-byon-build-pipelines-leads:
         description: Leads Team for BYON project
         maintainers:
-          - pacospace
           - oindrillac
         members:
         privacy: closed

--- a/github-config.yaml
+++ b/github-config.yaml
@@ -138,6 +138,29 @@ orgs:
         privacy: closed
         repos:
           devsecops: admin
+      scrum-maintainers:
+        description: The Scrum team for OSG
+        maintainers:
+        members:
+          - codificat
+          - durandom
+          - Gkrumbach07
+          - goern
+          - Gregory-Pereira
+          - harshad16
+          - HumairAK
+          - KPostOffice
+          - mayaCostantini
+          - mimotej
+          - SamoKopecky
+          - schwesig
+          - shreekarSS
+          - tumido
+          - VannTen
+          - xtuchyna
+        privacy: closed
+        repos:
+          scrum: maintain
       sp-metrics-maintainers:
         description: Maintainers Team for the Metrics sub-project
         maintainers:


### PR DESCRIPTION
As we use the scrum repo (issues basically) for Scrum, it is important to allow team members to be able to edit issues created by anyone.

Currently, for example, I can not directly edit the description of an existing issue that represents an Epic created by someone else to add a link to an issue that I created.

This PR adds a `scrum-maintainers` team with everyone in OSG and grants maintainer permissions to that team on the [scrum repo](https://github.com/open-services-group/scrum).

Additionally, adding another commit here to remove @fridex and @pacospace from OSG (thanks both!)